### PR TITLE
Add 1.14.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Minecraft bot. Currently used for stress testing.
 ## Requirements
 
 * Java 9
-* Minecraft 1.11-1.12 server
+* Minecraft 1.11-1.12 or 1.14 server
 
 ## Downloads
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>lambdaattack</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,9 +80,21 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.games647</groupId>
+            <artifactId>lambdaattack-version-1-14</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.Steveice10</groupId>
             <artifactId>opennbt</artifactId>
-            <version>1.0</version>
+            <version>1.3</version>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/com/github/games647/lambdaattack/LambdaAttack.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/LambdaAttack.java
@@ -38,7 +38,7 @@ public class LambdaAttack {
     }
 
     private boolean running = false;
-    private GameVersion gameVersion = GameVersion.VERSION_1_12;
+    private GameVersion gameVersion = GameVersion.VERSION_1_14;
 
     private List<Proxy> proxies;
     private List<String> names;

--- a/core/src/main/java/com/github/games647/lambdaattack/UniversalFactory.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/UniversalFactory.java
@@ -10,6 +10,8 @@ public class UniversalFactory {
                 return new com.github.games647.lambdaattack.version.v1_11.ProtocolWrapper(username);
             case VERSION_1_12:
                 return new com.github.games647.lambdaattack.version.v1_12.ProtocolWrapper(username);
+            case VERSION_1_14:
+                return new com.github.games647.lambdaattack.version.v1_14.ProtocolWrapper(username);
             default:
                 throw new IllegalArgumentException("Invalid game version");
         }
@@ -22,6 +24,9 @@ public class UniversalFactory {
                 break;
             case VERSION_1_12:
                 session.send(new com.github.steveice10.protocol.v1_12.packet.ingame.client.ClientChatPacket(message));
+                break;
+            case VERSION_1_14:
+                session.send(new com.github.steveice10.protocol.v1_14.packet.ingame.client.ClientChatPacket(message));
                 break;
             default:
                 throw new IllegalArgumentException("Invalid game version");

--- a/core/src/main/java/com/github/games647/lambdaattack/bot/Bot.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/bot/Bot.java
@@ -5,6 +5,7 @@ import com.github.games647.lambdaattack.UniversalFactory;
 import com.github.games647.lambdaattack.UniversalProtocol;
 import com.github.games647.lambdaattack.bot.listener.SessionListener111;
 import com.github.games647.lambdaattack.bot.listener.SessionListener112;
+import com.github.games647.lambdaattack.bot.listener.SessionListener114;
 import com.github.steveice10.mc.auth.data.GameProfile;
 import com.github.steveice10.mc.auth.exception.request.RequestException;
 import com.github.steveice10.packetlib.Client;
@@ -49,6 +50,9 @@ public class Bot {
                 break;
             case VERSION_1_12:
                 client.getSession().addListener(new SessionListener112(this));
+                break;
+            case VERSION_1_14:
+                client.getSession().addListener(new SessionListener114(this));
                 break;
             default:
                 throw new IllegalStateException("Unknown session listener");

--- a/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener.java
@@ -17,6 +17,7 @@ public abstract class SessionListener extends SessionAdapter {
 
     @Override
     public void disconnected(DisconnectedEvent disconnectedEvent) {
+        disconnectedEvent.getCause().printStackTrace();
         String reason = disconnectedEvent.getReason();
         owner.getLogger().log(Level.INFO, "Disconnected: {0}", reason);
     }

--- a/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener.java
@@ -17,7 +17,6 @@ public abstract class SessionListener extends SessionAdapter {
 
     @Override
     public void disconnected(DisconnectedEvent disconnectedEvent) {
-        disconnectedEvent.getCause().printStackTrace();
         String reason = disconnectedEvent.getReason();
         owner.getLogger().log(Level.INFO, "Disconnected: {0}", reason);
     }

--- a/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener114.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener114.java
@@ -11,10 +11,6 @@ import com.github.steveice10.protocol.v1_14.packet.ingame.server.entity.player.S
 
 import java.util.logging.Level;
 
-// ------------------------------
-// Copyright (c) PiggyPiglet 2019
-// https://www.piggypiglet.me
-// ------------------------------
 public class SessionListener114 extends SessionListener {
 
     public SessionListener114(Bot owner) {

--- a/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener114.java
+++ b/core/src/main/java/com/github/games647/lambdaattack/bot/listener/SessionListener114.java
@@ -1,0 +1,48 @@
+package com.github.games647.lambdaattack.bot.listener;
+
+import com.github.games647.lambdaattack.bot.Bot;
+import com.github.games647.lambdaattack.bot.EntitiyLocation;
+import com.github.steveice10.packetlib.event.session.PacketReceivedEvent;
+import com.github.steveice10.protocol.v1_14.data.message.Message;
+import com.github.steveice10.protocol.v1_14.packet.ingame.server.ServerChatPacket;
+import com.github.steveice10.protocol.v1_14.packet.ingame.server.ServerJoinGamePacket;
+import com.github.steveice10.protocol.v1_14.packet.ingame.server.entity.player.ServerPlayerHealthPacket;
+import com.github.steveice10.protocol.v1_14.packet.ingame.server.entity.player.ServerPlayerPositionRotationPacket;
+
+import java.util.logging.Level;
+
+// ------------------------------
+// Copyright (c) PiggyPiglet 2019
+// https://www.piggypiglet.me
+// ------------------------------
+public class SessionListener114 extends SessionListener {
+
+    public SessionListener114(Bot owner) {
+        super(owner);
+    }
+
+    @Override
+    public void packetReceived(PacketReceivedEvent receiveEvent) {
+        if (receiveEvent.getPacket() instanceof ServerChatPacket) {
+            ServerChatPacket chatPacket = receiveEvent.getPacket();
+            Message message = chatPacket.getMessage();
+            owner.getLogger().log(Level.INFO, "Received Message: {0}", message.getFullText());
+        } else if (receiveEvent.getPacket() instanceof ServerPlayerPositionRotationPacket) {
+            ServerPlayerPositionRotationPacket posPacket = receiveEvent.getPacket();
+
+            double posX = posPacket.getX();
+            double posY = posPacket.getY();
+            double posZ = posPacket.getZ();
+            float pitch = posPacket.getPitch();
+            float yaw = posPacket.getYaw();
+            EntitiyLocation location = new EntitiyLocation(posX, posY, posZ, pitch, yaw);
+            owner.setLocation(location);
+        } else if (receiveEvent.getPacket() instanceof ServerPlayerHealthPacket) {
+            ServerPlayerHealthPacket healthPacket = receiveEvent.getPacket();
+            owner.setHealth(healthPacket.getHealth());
+            owner.setFood(healthPacket.getFood());
+        } else if (receiveEvent.getPacket() instanceof ServerJoinGamePacket) {
+            super.onJoin();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>version</module>
         <module>version_1_11</module>
         <module>version_1_12</module>
+        <module>version_1_14</module>
         <module>core</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <name>LambdaAttack</name>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <description>Stress tester for minecraft servers</description>
     <url>https://github.com/games647/LambdaAttack</url>
 

--- a/version/pom.xml
+++ b/version/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>lambdaattack</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/version/src/main/java/com/github/games647/lambdaattack/GameVersion.java
+++ b/version/src/main/java/com/github/games647/lambdaattack/GameVersion.java
@@ -4,7 +4,9 @@ public enum GameVersion {
 
     VERSION_1_11("1.11"),
 
-    VERSION_1_12("1.12.2");
+    VERSION_1_12("1.12.2"),
+
+    VERSION_1_14("1.14.4");
 
     public static GameVersion findByName(String name) {
         switch (name) {
@@ -12,6 +14,8 @@ public enum GameVersion {
                 return VERSION_1_11;
             case "1.12":
                 return VERSION_1_12;
+            case "1.14":
+                return VERSION_1_14;
         }
 
         return null;

--- a/version_1_11/pom.xml
+++ b/version_1_11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>lambdaattack</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/version_1_12/pom.xml
+++ b/version_1_12/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>lambdaattack</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/version_1_14/pom.xml
+++ b/version_1_14/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.games647</groupId>
         <artifactId>lambdaattack</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/version_1_14/pom.xml
+++ b/version_1_14/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>lambdaattack-version-1-12</artifactId>
+    <artifactId>lambdaattack-version-1-14</artifactId>
     <packaging>jar</packaging>
 
     <build>
@@ -23,7 +23,7 @@
                     <relocations>
                         <relocation>
                             <pattern>com.github.steveice10.mc.protocol</pattern>
-                            <shadedPattern>com.github.steveice10.protocol.v1_12</shadedPattern>
+                            <shadedPattern>com.github.steveice10.protocol.v1_14</shadedPattern>
                         </relocation>
                     </relocations>
 
@@ -59,8 +59,8 @@
         <dependency>
             <groupId>com.github.Steveice10</groupId>
             <artifactId>MCProtocolLib</artifactId>
-            <!-- 1.12.2 -->
-            <version>1.12.2-2</version>
+            <!-- 1.14.4 -->
+            <version>1.14.4-1</version>
         </dependency>
 
         <dependency>

--- a/version_1_14/src/main/java/com/github/games647/lambdaattack/version/v1_14/ProtocolWrapper.java
+++ b/version_1_14/src/main/java/com/github/games647/lambdaattack/version/v1_14/ProtocolWrapper.java
@@ -5,10 +5,6 @@ import com.github.games647.lambdaattack.UniversalProtocol;
 import com.github.steveice10.mc.protocol.MinecraftProtocol;
 import com.github.steveice10.packetlib.packet.PacketProtocol;
 
-// ------------------------------
-// Copyright (c) PiggyPiglet 2019
-// https://www.piggypiglet.me
-// ------------------------------
 public class ProtocolWrapper extends MinecraftProtocol implements UniversalProtocol {
     public ProtocolWrapper(String username) {
         super(username);

--- a/version_1_14/src/main/java/com/github/games647/lambdaattack/version/v1_14/ProtocolWrapper.java
+++ b/version_1_14/src/main/java/com/github/games647/lambdaattack/version/v1_14/ProtocolWrapper.java
@@ -1,0 +1,26 @@
+package com.github.games647.lambdaattack.version.v1_14;
+
+import com.github.games647.lambdaattack.GameVersion;
+import com.github.games647.lambdaattack.UniversalProtocol;
+import com.github.steveice10.mc.protocol.MinecraftProtocol;
+import com.github.steveice10.packetlib.packet.PacketProtocol;
+
+// ------------------------------
+// Copyright (c) PiggyPiglet 2019
+// https://www.piggypiglet.me
+// ------------------------------
+public class ProtocolWrapper extends MinecraftProtocol implements UniversalProtocol {
+    public ProtocolWrapper(String username) {
+        super(username);
+    }
+
+    @Override
+    public PacketProtocol getProtocol() {
+        return this;
+    }
+
+    @Override
+    public GameVersion getGameVersion() {
+        return GameVersion.VERSION_1_14;
+    }
+}


### PR DESCRIPTION
Adds 1.14.4 support, tested on paper build 209, in offline mode with default settings (20 bots, 127.0.0.1, 25565). Tested with binary compiled using openjdk 11.2 on windows 10 home.

The protocolwrapper for 1.14 doesn't have the redundant constructors the other versions have, as the super constructors those other versions use seem to have been removed, and I don't see a need to find a replacement due to the current state of this project.

Also, just a reminder if this gets merged, make sure to update the repository description to `1.14` instead of `1.12`.